### PR TITLE
KubeJS 事件兼容

### DIFF
--- a/src/main/java/org/thexeler/freeepicgames/FreeEpicGamesJSPlugin.java
+++ b/src/main/java/org/thexeler/freeepicgames/FreeEpicGamesJSPlugin.java
@@ -1,0 +1,21 @@
+package org.thexeler.freeepicgames;
+
+import dev.latvian.mods.kubejs.event.EventGroupRegistry;
+import dev.latvian.mods.kubejs.plugin.KubeJSPlugin;
+import net.neoforged.neoforge.common.NeoForge;
+import org.thexeler.freeepicgames.events.kubejs.CommonEventsPostJS;
+import org.thexeler.freeepicgames.events.kubejs.FreeEpicGamesEventJS;
+
+public class FreeEpicGamesJSPlugin implements KubeJSPlugin {
+    @Override
+    public void init() {
+        NeoForge.EVENT_BUS.register(CommonEventsPostJS.class);
+    }
+
+    @Override
+    public void registerEvents(EventGroupRegistry registry) {
+        registry.register(FreeEpicGamesEventJS.MENU_EVENT);
+        registry.register(FreeEpicGamesEventJS.NPC_EVENT);
+        registry.register(FreeEpicGamesEventJS.RAID_EVENT);
+    }
+}

--- a/src/main/java/org/thexeler/freeepicgames/events/kubejs/CommonEventsPostJS.java
+++ b/src/main/java/org/thexeler/freeepicgames/events/kubejs/CommonEventsPostJS.java
@@ -1,0 +1,169 @@
+package org.thexeler.freeepicgames.events.kubejs;
+
+import dev.latvian.mods.kubejs.event.EventResult;
+import dev.latvian.mods.kubejs.script.ScriptType;
+import net.neoforged.bus.api.EventPriority;
+import net.neoforged.bus.api.SubscribeEvent;
+import org.thexeler.freeepicgames.events.MenuEvent;
+import org.thexeler.freeepicgames.events.NpcEvent;
+import org.thexeler.freeepicgames.events.RaidEvent;
+import org.thexeler.freeepicgames.storage.type.NpcType;
+
+public class CommonEventsPostJS {
+    // MenuEvent handlers
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void menuCreateEvent(MenuEvent.CreateEvent event) {
+        if (FreeEpicGamesEventJS.MENU_CREATE_EVENT.hasListeners()) {
+            FreeEpicGamesEventJS.MENU_CREATE_EVENT.post(new MenuEventJS.CreateEvent(event));
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void menuOpenedEvent(MenuEvent.OpenedEvent event) {
+        if (FreeEpicGamesEventJS.MENU_OPENED_EVENT.hasListeners()) {
+            FreeEpicGamesEventJS.MENU_OPENED_EVENT.post(new MenuEventJS.OpenedEvent(event));
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void menuCloseEvent(MenuEvent.CloseEvent event) {
+        if (FreeEpicGamesEventJS.MENU_CLOSE_EVENT.hasListeners()) {
+            FreeEpicGamesEventJS.MENU_CLOSE_EVENT.post(new MenuEventJS.CloseEvent(event));
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void menuClickEvent(MenuEvent.ClickEvent event) {
+        if (FreeEpicGamesEventJS.MENU_CLICK_EVENT.hasListeners()) {
+            EventResult result = FreeEpicGamesEventJS.MENU_CLICK_EVENT.post(new MenuEventJS.ClickEvent(event));
+            if (result.interruptFalse()) {
+                event.setCanceled(true);
+            }
+        }
+    }
+
+    // NpcEvent handlers
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void npcCreateEvent(NpcEvent.Create event) {
+        if (FreeEpicGamesEventJS.NPC_CREATE_EVENT.hasListeners()) {
+            NpcType npcType = event.getView().getNpcType();
+            if (FreeEpicGamesEventJS.NPC_CREATE_EVENT.hasListeners(npcType)) {
+                FreeEpicGamesEventJS.NPC_CREATE_EVENT.post(ScriptType.SERVER, npcType, new NpcEventJS.Create(event));
+            }
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void npcJoinEvent(NpcEvent.Join event) {
+        if (FreeEpicGamesEventJS.NPC_JOIN_EVENT.hasListeners()) {
+            NpcType npcType = event.getView().getNpcType();
+            if (FreeEpicGamesEventJS.NPC_JOIN_EVENT.hasListeners(npcType)) {
+                FreeEpicGamesEventJS.NPC_JOIN_EVENT.post(ScriptType.SERVER, npcType, new NpcEventJS.Join(event));
+            }
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void npcDeathEvent(NpcEvent.Death event) {
+        if (FreeEpicGamesEventJS.NPC_DEATH_EVENT.hasListeners()) {
+            NpcType npcType = event.getView().getNpcType();
+            if (FreeEpicGamesEventJS.NPC_DEATH_EVENT.hasListeners(npcType)) {
+                EventResult result = FreeEpicGamesEventJS.NPC_DEATH_EVENT.post(ScriptType.SERVER, npcType, new NpcEventJS.Death(event));
+                if (result.interruptFalse()) {
+                    event.setCanceled(true);
+                }
+            }
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void npcInteractEvent(NpcEvent.Interact event) {
+        if (FreeEpicGamesEventJS.NPC_INTERACT_EVENT.hasListeners()) {
+            NpcType npcType = event.getView().getNpcType();
+            if (FreeEpicGamesEventJS.NPC_INTERACT_EVENT.hasListeners(npcType)) {
+                FreeEpicGamesEventJS.NPC_INTERACT_EVENT.post(ScriptType.SERVER, npcType, new NpcEventJS.Interact(event));
+            }
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void npcDamageEvent(NpcEvent.Damage event) {
+        if (FreeEpicGamesEventJS.NPC_DAMAGE_EVENT.hasListeners()) {
+            NpcType npcType = event.getView().getNpcType();
+            if (FreeEpicGamesEventJS.NPC_DAMAGE_EVENT.hasListeners(npcType)) {
+                EventResult result = FreeEpicGamesEventJS.NPC_DAMAGE_EVENT.post(ScriptType.SERVER, npcType, new NpcEventJS.Damage(event));
+                if (result.interruptFalse()) {
+                    event.setCanceled(true);
+                }
+            }
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void npcTickEvent(NpcEvent.Tick event) {
+        if (FreeEpicGamesEventJS.NPC_TICK_EVENT.hasListeners()) {
+            NpcType npcType = event.getView().getNpcType();
+            if (FreeEpicGamesEventJS.NPC_TICK_EVENT.hasListeners(npcType)) {
+                FreeEpicGamesEventJS.NPC_TICK_EVENT.post(ScriptType.SERVER, npcType, new NpcEventJS.Tick(event));
+            }
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void npcKilledEvent(NpcEvent.Killed event) {
+        if (FreeEpicGamesEventJS.NPC_KILLED_EVENT.hasListeners()) {
+            NpcType npcType = event.getView().getNpcType();
+            if (FreeEpicGamesEventJS.NPC_KILLED_EVENT.hasListeners(npcType)) {
+                EventResult result = FreeEpicGamesEventJS.NPC_KILLED_EVENT.post(ScriptType.SERVER, npcType, new NpcEventJS.Killed(event));
+                if (result.interruptFalse()) {
+                    event.setCanceled(true);
+                }
+            }
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void npcAttackEvent(NpcEvent.Attack event) {
+        if (FreeEpicGamesEventJS.NPC_ATTACK_EVENT.hasListeners()) {
+            NpcType npcType = event.getView().getNpcType();
+            if (FreeEpicGamesEventJS.NPC_ATTACK_EVENT.hasListeners(npcType)) {
+                FreeEpicGamesEventJS.NPC_ATTACK_EVENT.post(ScriptType.SERVER, npcType, new NpcEventJS.Attack(event));
+            }
+        }
+    }
+
+    // RaidEvent handlers
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void raidBuildEvent(RaidEvent.BuildEvent event) {
+        if (FreeEpicGamesEventJS.RAID_BUILD_EVENT.hasListeners()) {
+            FreeEpicGamesEventJS.RAID_BUILD_EVENT.post(new RaidEventJS.BuildEvent(event));
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void raidDestroyEvent(RaidEvent.DestroyEvent event) {
+        if (FreeEpicGamesEventJS.RAID_DESTROY_EVENT.hasListeners()) {
+            EventResult result = FreeEpicGamesEventJS.RAID_DESTROY_EVENT.post(new RaidEventJS.DestroyEvent(event));
+            if (result.interruptFalse()) {
+                event.setCanceled(true);
+            }
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void raidOpenTreasureEvent(RaidEvent.OpenTreasureEvent event) {
+        if (FreeEpicGamesEventJS.RAID_OPEN_TREASURE_EVENT.hasListeners()) {
+            EventResult result = FreeEpicGamesEventJS.RAID_OPEN_TREASURE_EVENT.post(new RaidEventJS.OpenTreasureEvent(event));
+            if (result.interruptFalse()) {
+                event.setCanceled(true);
+            }
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void raidTickEvent(RaidEvent.TickEvent event) {
+        if (FreeEpicGamesEventJS.RAID_TICK_EVENT.hasListeners()) {
+            FreeEpicGamesEventJS.RAID_TICK_EVENT.post(new RaidEventJS.TickEvent(event));
+        }
+    }
+}

--- a/src/main/java/org/thexeler/freeepicgames/events/kubejs/FreeEpicGamesEventJS.java
+++ b/src/main/java/org/thexeler/freeepicgames/events/kubejs/FreeEpicGamesEventJS.java
@@ -1,0 +1,47 @@
+package org.thexeler.freeepicgames.events.kubejs;
+
+import dev.latvian.mods.kubejs.event.EventGroup;
+import dev.latvian.mods.kubejs.event.EventHandler;
+import dev.latvian.mods.kubejs.event.EventTargetType;
+import dev.latvian.mods.kubejs.event.TargetedEventHandler;
+import dev.latvian.mods.rhino.type.TypeInfo;
+import org.thexeler.freeepicgames.storage.type.NpcType;
+
+public interface FreeEpicGamesEventJS {
+    EventGroup MENU_EVENT = EventGroup.of("MenuEvent");
+    EventGroup NPC_EVENT = EventGroup.of("NpcEvent");
+    EventGroup RAID_EVENT = EventGroup.of("RaidEvent");
+
+    EventTargetType<NpcType> NPC_TYPE = EventTargetType.create(NpcType.class).transformer(o -> {
+        if (o == null) {
+            return null;
+        } else if (o instanceof NpcType npcType) {
+            return npcType;
+        } else if (o instanceof String name) {
+            return name.isBlank() ? null : NpcType.getType(name);
+        }
+        return null;
+    }).describeType(TypeInfo.of(NpcType.class));
+
+    // MenuEvent handlers
+    EventHandler MENU_CREATE_EVENT = MENU_EVENT.server("Create", () -> MenuEventJS.CreateEvent.class);
+    EventHandler MENU_OPENED_EVENT = MENU_EVENT.server("Opened", () -> MenuEventJS.OpenedEvent.class);
+    EventHandler MENU_CLOSE_EVENT = MENU_EVENT.server("Close", () -> MenuEventJS.CloseEvent.class);
+    EventHandler MENU_CLICK_EVENT = MENU_EVENT.server("Click", () -> MenuEventJS.ClickEvent.class).hasResult();
+
+    // NpcEvent handlers
+    TargetedEventHandler<NpcType> NPC_CREATE_EVENT = NPC_EVENT.server("Create", () -> NpcEventJS.Create.class).supportsTarget(NPC_TYPE);
+    TargetedEventHandler<NpcType> NPC_JOIN_EVENT = NPC_EVENT.server("Join", () -> NpcEventJS.Join.class).supportsTarget(NPC_TYPE);
+    TargetedEventHandler<NpcType> NPC_DEATH_EVENT = NPC_EVENT.server("Death", () -> NpcEventJS.Death.class).hasResult().supportsTarget(NPC_TYPE);
+    TargetedEventHandler<NpcType> NPC_INTERACT_EVENT = NPC_EVENT.server("Interact", () -> NpcEventJS.Interact.class).supportsTarget(NPC_TYPE);
+    TargetedEventHandler<NpcType> NPC_DAMAGE_EVENT = NPC_EVENT.server("Damage", () -> NpcEventJS.Damage.class).hasResult().supportsTarget(NPC_TYPE);
+    TargetedEventHandler<NpcType> NPC_TICK_EVENT = NPC_EVENT.server("Tick", () -> NpcEventJS.Tick.class).supportsTarget(NPC_TYPE);
+    TargetedEventHandler<NpcType> NPC_KILLED_EVENT = NPC_EVENT.server("Killed", () -> NpcEventJS.Killed.class).hasResult().supportsTarget(NPC_TYPE);
+    TargetedEventHandler<NpcType> NPC_ATTACK_EVENT = NPC_EVENT.server("Attack", () -> NpcEventJS.Attack.class).supportsTarget(NPC_TYPE);
+
+    // RaidEvent handlers
+    EventHandler RAID_BUILD_EVENT = RAID_EVENT.server("Build", () -> RaidEventJS.BuildEvent.class);
+    EventHandler RAID_DESTROY_EVENT = RAID_EVENT.server("Destroy", () -> RaidEventJS.DestroyEvent.class).hasResult();
+    EventHandler RAID_OPEN_TREASURE_EVENT = RAID_EVENT.server("OpenTreasure", () -> RaidEventJS.OpenTreasureEvent.class).hasResult();
+    EventHandler RAID_TICK_EVENT = RAID_EVENT.server("Tick", () -> RaidEventJS.TickEvent.class);
+}

--- a/src/main/java/org/thexeler/freeepicgames/events/kubejs/MenuEventJS.java
+++ b/src/main/java/org/thexeler/freeepicgames/events/kubejs/MenuEventJS.java
@@ -1,0 +1,45 @@
+package org.thexeler.freeepicgames.events.kubejs;
+
+import dev.latvian.mods.kubejs.event.KubeEvent;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ClickType;
+import org.thexeler.freeepicgames.events.MenuEvent;
+import org.thexeler.freeepicgames.utils.chestmenu.EventChestMenu;
+
+@Getter
+@AllArgsConstructor
+public abstract class MenuEventJS implements KubeEvent {
+    protected final Player player;
+    protected final int index;
+    protected final EventChestMenu menu;
+
+    public static class CreateEvent extends MenuEventJS {
+        public CreateEvent(MenuEvent.CreateEvent createEvent) {
+            super(createEvent.getPlayer(), createEvent.getIndex(), createEvent.getMenu());
+        }
+    }
+
+    public static class OpenedEvent extends MenuEventJS {
+        public OpenedEvent(MenuEvent.OpenedEvent openedEvent) {
+            super(openedEvent.getPlayer(), openedEvent.getIndex(), openedEvent.getMenu());
+        }
+    }
+
+    public static class CloseEvent extends MenuEventJS {
+        public CloseEvent(MenuEvent.CloseEvent closeEvent) {
+            super(closeEvent.getPlayer(), closeEvent.getIndex(), closeEvent.getMenu());
+        }
+    }
+
+    @Getter
+    public static class ClickEvent extends MenuEventJS {
+        private final ClickType clickType;
+
+        public ClickEvent(MenuEvent.ClickEvent clickEvent) {
+            super(clickEvent.getPlayer(), clickEvent.getIndex(), clickEvent.getMenu());
+            this.clickType = clickEvent.getClickType();
+        }
+    }
+}

--- a/src/main/java/org/thexeler/freeepicgames/events/kubejs/NpcEventJS.java
+++ b/src/main/java/org/thexeler/freeepicgames/events/kubejs/NpcEventJS.java
@@ -1,0 +1,103 @@
+package org.thexeler.freeepicgames.events.kubejs;
+
+import dev.latvian.mods.kubejs.event.KubeEvent;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.neoforged.neoforge.common.damagesource.DamageContainer;
+import org.thexeler.freeepicgames.events.NpcEvent;
+import org.thexeler.freeepicgames.storage.view.NpcView;
+
+@Getter
+@AllArgsConstructor
+public abstract class NpcEventJS implements KubeEvent {
+    protected final Entity entity;
+    protected final NpcView view;
+
+    public static class Create extends NpcEventJS {
+        public Create(NpcEvent.Create createEvent) {
+            super(createEvent.getEntity(), createEvent.getView());
+        }
+    }
+
+    @Getter
+    public static class Join extends NpcEventJS {
+        private final ServerLevel level;
+
+        public Join(NpcEvent.Join joinEvent) {
+            super(joinEvent.getEntity(), joinEvent.getView());
+            this.level = joinEvent.getLevel();
+        }
+    }
+
+    @Getter
+    public static class Death extends NpcEventJS {
+        private final DamageSource source;
+
+        public Death(NpcEvent.Death deathEvent) {
+            super(deathEvent.getEntity(), deathEvent.getView());
+            this.source = deathEvent.getSource();
+        }
+    }
+
+    @Getter
+    public static class Interact extends NpcEventJS {
+        private final Player player;
+
+        public Interact(NpcEvent.Interact interactEvent) {
+            super(interactEvent.getEntity(), interactEvent.getView());
+            this.player = interactEvent.getPlayer();
+        }
+    }
+
+    @Getter
+    public static class Damage extends NpcEventJS {
+        private final DamageSource source;
+        private float amount;
+        private final DamageContainer container;
+
+        public Damage(NpcEvent.Damage damageEvent) {
+            super(damageEvent.getEntity(), damageEvent.getView());
+            this.source = damageEvent.getSource();
+            this.amount = damageEvent.getAmount();
+            this.container = damageEvent.getContainer();
+        }
+    }
+
+    public static class Tick extends NpcEventJS {
+        public Tick(NpcEvent.Tick tickEvent) {
+            super(tickEvent.getEntity(), tickEvent.getView());
+        }
+    }
+
+    @Getter
+    public static class Killed extends NpcEventJS {
+        private final Entity killedEntity;
+        private final DamageSource source;
+
+        public Killed(NpcEvent.Killed killedEvent) {
+            super(killedEvent.getEntity(), killedEvent.getView());
+            this.killedEntity = killedEvent.getEntity();
+            this.source = killedEvent.getSource();
+        }
+    }
+
+    @Getter
+    public static class Attack extends NpcEventJS {
+        private final Entity target;
+        private final DamageSource source;
+        private float amount;
+        private final DamageContainer container;
+
+        public Attack(NpcEvent.Attack attackEvent) {
+            super(attackEvent.getEntity(), attackEvent.getView());
+            this.target = attackEvent.getTarget();
+            this.source = attackEvent.getSource();
+            this.amount = attackEvent.getAmount();
+            this.container = attackEvent.getContainer();
+        }
+    }
+}

--- a/src/main/java/org/thexeler/freeepicgames/events/kubejs/RaidEventJS.java
+++ b/src/main/java/org/thexeler/freeepicgames/events/kubejs/RaidEventJS.java
@@ -1,0 +1,45 @@
+package org.thexeler.freeepicgames.events.kubejs;
+
+import dev.latvian.mods.kubejs.event.KubeEvent;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.Container;
+import org.thexeler.freeepicgames.events.RaidEvent;
+import org.thexeler.freeepicgames.storage.view.RaidInstanceView;
+
+@Getter
+@AllArgsConstructor
+public abstract class RaidEventJS implements KubeEvent {
+    protected final RaidInstanceView view;
+
+    public static class BuildEvent extends RaidEventJS {
+        public BuildEvent(RaidEvent.BuildEvent buildEvent) {
+            super(buildEvent.getView());
+        }
+    }
+
+    public static class DestroyEvent extends RaidEventJS {
+        public DestroyEvent(RaidEvent.DestroyEvent destroyEvent) {
+            super(destroyEvent.getView());
+        }
+    }
+
+    @Getter
+    public static class OpenTreasureEvent extends RaidEventJS {
+        private final Container container;
+        private final ServerPlayer player;
+
+        public OpenTreasureEvent(RaidEvent.OpenTreasureEvent openTreasureEvent) {
+            super(openTreasureEvent.getView());
+            this.container = openTreasureEvent.getContainer();
+            this.player = openTreasureEvent.getPlayer();
+        }
+    }
+
+    public static class TickEvent extends RaidEventJS {
+        public TickEvent(RaidEvent.TickEvent tickEvent) {
+            super(tickEvent.getView());
+        }
+    }
+}

--- a/src/main/resources/kubejs.plugins.txt
+++ b/src/main/resources/kubejs.plugins.txt
@@ -1,0 +1,1 @@
+org.thexeler.freeepicgames.FreeEpicGamesJSPlugin


### PR DESCRIPTION
将NeoForge转成KubeJS事件，在无KubeJS的情况下也能支持运行模组，所有的NpcEvent提供第一个参数来指点Npc的类型